### PR TITLE
Added stricter flags: ` -Wunused -Wextra -std=gnu11`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@ driver
 nul
 notes.org
 .ruby-version
-*swp
+*.swp
 tags
+*.gch
 
 # For autotools build system
 .deps/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ driver
 nul
 notes.org
 .ruby-version
+*swp
+tags
 
 # For autotools build system
 .deps/

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,5 +9,5 @@ endif
 bin_PROGRAMS = driver
 driver_SOURCES = common.c driver.c $(platformsrc)
 
-AM_CFLAGS = -Wall -Werror
+AM_CFLAGS = -Wall -Werror -Wunused -Wextra -std=gnu11
 AUTOMAKE_OPTIONS = foreign

--- a/common.c
+++ b/common.c
@@ -38,9 +38,9 @@ int_comp(const void *key, const void *memb)
 char *
 grep_awk(FILE *fp, const char *fstr, int nfield, const char *delim)
 {
-  char *line = (char *)calloc(500, sizeof(char));
   char *ret = NULL;
   int i;
+  char *line = (char *)calloc(500, sizeof(char));
   check_mem(line);
   while (fgets(line, 400, fp) != NULL) {
     if (strncasecmp(line, fstr, strlen(fstr)) == 0){

--- a/common.c
+++ b/common.c
@@ -36,7 +36,7 @@ int_comp(const void *key, const void *memb)
 
 
 char *
-grep_awk(FILE *fp, char *fstr, int nfield, const char *delim)
+grep_awk(FILE *fp, const char *fstr, int nfield, const char *delim)
 {
   char *line = (char *)calloc(500, sizeof(char));
   char *ret = NULL;

--- a/common.c
+++ b/common.c
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
 #include <math.h>
 
 #include "common.h"
@@ -37,12 +36,12 @@ int_comp(const void *key, const void *memb)
 
 
 char *
-grep_awk(FILE *fp, char *fstr, int nfield, char *delim)
+grep_awk(FILE *fp, char *fstr, int nfield, const char *delim)
 {
   char *line = (char *)calloc(500, sizeof(char));
-  check_mem(line);
   char *ret = NULL;
   int i;
+  check_mem(line);
   while (fgets(line, 400, fp) != NULL) {
     if (strncasecmp(line, fstr, strlen(fstr)) == 0){
       ret = strtok(line, delim);
@@ -64,7 +63,7 @@ grep_awk(FILE *fp, char *fstr, int nfield, char *delim)
 }
 
 char *
-squeeze(char *string, char *chars)
+squeeze(char *string, const char *chars)
 {
   char *src = string;
   char *target = string;

--- a/common.h
+++ b/common.h
@@ -19,7 +19,7 @@ char *squeeze(char *, const char *);
 
 #define clean_errno() (errno == 0 ? "None" : strerror(errno))
 
-#define log_err(M, ...) fprintf(stderr, "[ERROR] (%s:%d:%s: errno: %s) " M "\n", __FILE__, __LINE__, __FUNCTION__, clean_errno(), ##__VA_ARGS__)
+#define log_err(M, ...) fprintf(stderr, "[ERROR] (%s:%d:%s: errno: %d, %s) " M "\n", __FILE__, __LINE__, __FUNCTION__, errno, clean_errno(), ##__VA_ARGS__)
 
 #define log_warn(M, ...) fprintf(stderr, "[WARN] (%s:%d: errno: %s) " M "\n", __FILE__, __LINE__, clean_errno(), ##__VA_ARGS__)
 

--- a/common.h
+++ b/common.h
@@ -1,15 +1,15 @@
 #ifndef __common_h
 #define __common_h
 
-float percentage(unsigned long int, unsigned long int);
-int str_comp(const void *, const void *);
-int int_comp(const void *, const void *);
-char *grep_awk(FILE *, char *, int, char *);
-char *squeeze(char *, char *);
-
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
+
+float percentage(unsigned long int, unsigned long int);
+int str_comp(const void *, const void *);
+int int_comp(const void *, const void *);
+char *grep_awk(FILE *, char *, int, const char *);
+char *squeeze(char *, const char *);
 
 #ifdef NDEBUG
 #define debug(M, ...)

--- a/common.h
+++ b/common.h
@@ -8,7 +8,7 @@
 float percentage(unsigned long int, unsigned long int);
 int str_comp(const void *, const void *);
 int int_comp(const void *, const void *);
-char *grep_awk(FILE *, char *, int, const char *);
+char *grep_awk(FILE *, const char *, int, const char *);
 char *squeeze(char *, const char *);
 
 #ifdef NDEBUG

--- a/driver.c
+++ b/driver.c
@@ -139,10 +139,6 @@ test_boottime()
 {
   unsigned long t = get_boot_time();
   printf(" Boot time \n");
-  if (t == -1) {
-    printf("Aborting\n");
-    return;
-  }
   printf("%ld\n\n", t);
 }
 

--- a/pslib.h
+++ b/pslib.h
@@ -170,8 +170,8 @@ typedef struct {
 } CpuTimes;
 
 typedef struct {
-  unsigned int pid;
-  unsigned int ppid;
+  pid_t pid;
+  pid_t ppid;
   char *name;
   char *exe;
   char *cmdline;
@@ -213,7 +213,7 @@ double *cpu_util_percent(int percpu, CpuTimes *prev_times);
 
 int cpu_count(int);
 
-Process *get_process(unsigned int);
+Process *get_process(pid_t);
 void free_process(Process *);
 
 #endif

--- a/pslib_linux.c
+++ b/pslib_linux.c
@@ -185,9 +185,9 @@ get_ppid(unsigned pid)
   fp = fopen(procfile,"r");
   check(fp, "Couldn't open process status file");
   tmp = grep_awk(fp, "PPid", 1, ":");
-  ppid = tmp?strtoul(tmp, NULL, 10):-1;
+  ppid = tmp ? strtoul(tmp, NULL, 10) : -1;
 
-  check(ppid != -1, "Couldnt' find Ppid in process status file");
+  check(ppid != -1, "Couldnt' find PPid in process status file");
   fclose(fp);
   free(tmp);
 
@@ -248,7 +248,7 @@ get_exe(unsigned pid)
   while(ret == bufsize -1 ) {
     /* Buffer filled. Might be incomplete. Increase size and try again. */
     bufsize *= 2;
-    tmp = realloc(tmp, bufsize);
+    tmp = (char *)realloc(tmp, bufsize);
     ret = readlink(procfile, tmp, bufsize - 1);
     check(ret != -1, "Couldn't expand symbolic link");
   }
@@ -369,7 +369,7 @@ get_terminal(unsigned int pid)
   while(ret == bufsize -1 ) {
     /* Buffer filled. Might be incomplete. Increase size and try again. */
     bufsize *= 2;
-    tmp = realloc(tmp, bufsize);
+    tmp = (char *)realloc(tmp, bufsize);
     ret = readlink(procfile, tmp, bufsize - 1);
     check(ret != -1, "Couldn't expand symbolic link");
   }
@@ -475,7 +475,7 @@ disk_partitions(int physical)
 
     if (ret->nitems == nparts) {
       nparts *= 2;
-      partitions = realloc(partitions, sizeof(DiskPartition) * nparts);
+      partitions = (DiskPartition *)realloc(partitions, sizeof(DiskPartition) * nparts);
       check_mem(partitions);
       ret->partitions = partitions;
       d = ret->partitions + ret->nitems; /* Move the cursor to the correct
@@ -737,7 +737,7 @@ get_users ()
 
     if (ret->nitems == nusers) { /* More users than we've allocated space for. */
       nusers *= 2;
-      users = realloc(users, sizeof(Users) * nusers);
+      users = (Users *)realloc(users, sizeof(Users) * nusers);
       check_mem(users);
       ret->users = users;
       u = ret->users + ret->nitems; /* Move the cursor to the correct

--- a/pslib_linux.c
+++ b/pslib_linux.c
@@ -134,12 +134,12 @@ physical_cpu_count()
 }
 
 char **
-get_physical_devices(int *ndevices)
+get_physical_devices(size_t *ndevices)
 {
   FILE *fs = NULL;
   char *line = NULL;
   char **retval = NULL;
-  int i;
+  unsigned int i;
   *ndevices = 0;
 
   line = (char *)calloc(60, sizeof(char));
@@ -441,7 +441,7 @@ disk_partitions(int physical)
   struct mntent *entry;
   int nparts = 5;
   char **phys_devices = NULL;
-  int nphys_devices;
+  size_t nphys_devices;
   int i;
 
   DiskPartition *partitions = (DiskPartition *)calloc(nparts, sizeof(DiskPartition));
@@ -459,9 +459,8 @@ disk_partitions(int physical)
   phys_devices = get_physical_devices(&nphys_devices);
 
   while ((entry = getmntent(file))) {
-    if (physical && ! lfind(&entry->mnt_type, phys_devices,
-                            (size_t *)&nphys_devices, sizeof(char *),
-                            str_comp)) {
+    if (physical && ! lfind(&entry->mnt_type, phys_devices, &nphys_devices,
+                            sizeof(char *), str_comp)) {
       /* Skip this partition since we only need physical partitions */
       continue;
     }

--- a/pslib_linux.c
+++ b/pslib_linux.c
@@ -173,11 +173,11 @@ get_physical_devices(size_t *ndevices)
 }
 
 
-static unsigned int
-get_ppid(unsigned pid)
+static pid_t
+get_ppid(pid_t pid)
 {
   FILE *fp = NULL;
-  int ppid = -1;
+  pid_t ppid = -1;
   char *tmp;
   char procfile[50];
 
@@ -198,7 +198,7 @@ get_ppid(unsigned pid)
 }
 
 static char *
-get_procname(unsigned pid)
+get_procname(pid_t pid)
 {
   FILE *fp = NULL;
   char *tmp;
@@ -222,7 +222,7 @@ get_procname(unsigned pid)
 }
 
 static char *
-get_exe(unsigned pid)
+get_exe(pid_t pid)
 {
   FILE *fp = NULL;
   char *tmp = NULL;
@@ -261,7 +261,7 @@ get_exe(unsigned pid)
 }
 
 static char *
-get_cmdline(unsigned int pid)
+get_cmdline(pid_t pid)
 {
   FILE *fp = NULL;
   char procfile[50];
@@ -284,7 +284,7 @@ get_cmdline(unsigned int pid)
 }
 
 static unsigned long
-get_create_time(unsigned int pid)
+get_create_time(pid_t pid)
 {
   FILE *fp = NULL;
   char procfile[50];
@@ -303,7 +303,7 @@ get_create_time(unsigned int pid)
 }
 
 static unsigned int *
-get_ids(unsigned int pid, const char *field)
+get_ids(pid_t pid, const char *field)
 /* field parameter is used to determine which line to parse (Uid or Gid) */
 {
   FILE *fp = NULL;
@@ -354,7 +354,7 @@ get_username(unsigned int ruid)
 }
 
 static char *
-get_terminal(unsigned int pid)
+get_terminal(pid_t pid)
 {
   FILE *fp = NULL;
   char *tmp = NULL;
@@ -1007,7 +1007,7 @@ cpu_count(int logical)
 
 
 Process *
-get_process(unsigned pid)
+get_process(pid_t pid)
 {
   Process *retval = (Process *)calloc(1, sizeof(Process));
   unsigned int *uids = NULL;


### PR DESCRIPTION
Fixes for multiple resulting errors like:

```
driver.c: In function ‘test_boottime’:
driver.c:142:9: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   if (t == -1) {
         ^
```
and
```
kartik@breogan:~/Projects/cpslib$ make
make  all-am
make[1]: Entering directory '/home/kartik/Projects/cpslib'
gcc -DHAVE_CONFIG_H -I.    -Wall -Werror -Wunused -Wextra -std=gnu11 -g -O2 -MT driver.o -MD -MP -MF .deps/driver.Tpo -c -o driver.o driver.c
mv -f .deps/driver.Tpo .deps/driver.Po
gcc -DHAVE_CONFIG_H -I.    -Wall -Werror -Wunused -Wextra -std=gnu11 -g -O2 -MT pslib_linux.o -MD -MP -MF .deps/pslib_linux.Tpo -c -o pslib_linux.o pslib_linux.c
pslib_linux.c: In function ‘get_physical_devices’:
pslib_linux.c:170:19: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
     for (i = 0; i < *ndevices; i++) 
                   ^
pslib_linux.c: In function ‘get_ppid’:
pslib_linux.c:188:36: error: signed and unsigned type in conditional expression [-Werror=sign-compare]
   ppid = tmp?strtoul(tmp, NULL, 10):-1;
                                    ^
In file included from pslib_linux.c:18:0:
pslib_linux.c:190:14: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   check(ppid != -1, "Couldnt' find Ppid in process status file");
              ^
common.h:28:32: note: in definition of macro ‘check’
 #define check(A, M, ...) if (!(A)) {log_err(M, ##__VA_ARGS__); errno=0; goto error; }
                                ^
pslib_linux.c: In function ‘get_cmdline’:
pslib_linux.c:275:14: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   check(size != -1, "Couldn't read command line from /proc");
              ^
common.h:28:32: note: in definition of macro ‘check’
 #define check(A, M, ...) if (!(A)) {log_err(M, ##__VA_ARGS__); errno=0; goto error; }
                                ^
pslib_linux.c: In function ‘disk_partitions’:
pslib_linux.c:486:17: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   for (i = 0; i < nphys_devices; i++)
                 ^
In file included from pslib_linux.c:18:0:
pslib_linux.c: In function ‘get_boot_time’:
pslib_linux.c:787:13: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   check(ret != -1, "Couldn't find 'btime' line in /proc/stat");
             ^
common.h:28:32: note: in definition of macro ‘check’
 #define check(A, M, ...) if (!(A)) {log_err(M, ##__VA_ARGS__); errno=0; goto error; }
                                ^
pslib_linux.c: In function ‘virtual_memory’:
pslib_linux.c:830:14: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   if (cached == -1 || active == -1 || inactive == -1) {
              ^
pslib_linux.c:830:30: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   if (cached == -1 || active == -1 || inactive == -1) {
                              ^
pslib_linux.c:830:48: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   if (cached == -1 || active == -1 || inactive == -1) {
                                                ^
pslib_linux.c: In function ‘swap_memory’:
pslib_linux.c:882:11: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   if (sin == -1 || sout == -1) {
           ^
pslib_linux.c:882:25: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   if (sin == -1 || sout == -1) {
                         ^
cc1: all warnings being treated as errors
Makefile:406: recipe for target 'pslib_linux.o' failed
make[1]: *** [pslib_linux.o] Error 1
make[1]: Leaving directory '/home/kartik/Projects/cpslib'
Makefile:295: recipe for target 'all' failed
make: *** [all] Error 2
```


Valgrind seems happy after the changes:
```
==18801== HEAP SUMMARY:
==18801==     in use at exit: 0 bytes in 0 blocks
==18801==   total heap usage: 361 allocs, 361 frees, 57,167 bytes allocated
==18801== 
==18801== All heap blocks were freed -- no leaks are possible
==18801== 
==18801== For counts of detected and suppressed errors, rerun with: -v
==18801== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```